### PR TITLE
Update pyafipws source

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pyafipws
+pyafipws @ git+https://github.com/reingart/pyafipws.git


### PR DESCRIPTION
## Summary
- install pyafipws from GitHub instead of PyPI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849ca34d1208329ab58f6c996ddd0b0

## Summary by Sourcery

Enhancements:
- Install pyafipws from its GitHub repository rather than from PyPI